### PR TITLE
Remove metadata key from checkpoint when not used

### DIFF
--- a/src/nn_core/callbacks.py
+++ b/src/nn_core/callbacks.py
@@ -53,4 +53,6 @@ class NNTemplateCore(Callback):
     ) -> None:
         if self._is_nnlogger(trainer):
             trainer.logger.on_save_checkpoint(trainer=trainer, pl_module=pl_module, checkpoint=checkpoint)
-            checkpoint[METADATA_KEY] = trainer.datamodule.metadata
+            metadata = getattr(trainer.datamodule, "metadata", None)
+            if metadata is not None:
+                checkpoint[METADATA_KEY] = metadata


### PR DESCRIPTION
This PR fixes a bug when saving checkpoints with empty metadata. The metadata is saved in the checkpoint only if it is implemented in the datamodule class. Otherwise, it is ignored.